### PR TITLE
Fix authentication for v1 HA API sync

### DIFF
--- a/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
+++ b/pfSense-pkg-API/files/etc/inc/api/framework/APITools.inc
@@ -1196,6 +1196,7 @@ function sync() {
                 $protocol."://".$node.":".$port."/api/v1/system/api/sync",
                 "PUT",
                 $pkg_conf,
+                [],
                 $pkg_conf["hasync_username"],
                 $pkg_conf["hasync_password"]
             );


### PR DESCRIPTION
Related to #935

## Summary

Fixes authentication for the v1 HA API synchronization.

The call to `api_request()` did not provide the `$headers` argument, causing the configured HA username and password to be shifted into the wrong function parameters. As a result, HTTP Basic Authentication was not configured and the remote peer reported the request as coming from user `unknown`.

This adds the missing empty headers array so the HA credentials are passed to the correct arguments.

## Testing

Tested with:

- pfSense CE 2.7.2
- pfSense API v1.9.0
- HA API synchronization between two pfSense nodes

Before the change, the remote peer logged:

```text
webConfigurator authentication error for user 'unknown'
```

After the change, HA API synchronization succeeds.